### PR TITLE
Trimmed name strings before finding agent

### DIFF
--- a/src/lib/api/users.js
+++ b/src/lib/api/users.js
@@ -13,8 +13,10 @@ const findOrCreateAgentByUser = (user, res, next) => {
       console.error("Error finding agent by ID: ", err);
     }
     if (!agentByUserId) {
+      const firstName = user.firstName.trim();
+      const lastName = user.lastName.trim();
       Agent.findOneAndUpdate(
-        { firstName: user.firstName, lastName: user.lastName },
+        { firstName, lastName },
         {
           userId: user._id,
           firstName: user.firstName,


### PR DESCRIPTION
Some duplicate agents have been created because some first names in Google have a space at the end
Trimming the strings now to prevent that from happening