### PR TITLE
Database Migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 # testing
 /coverage
 
+# migrations 
+/migrations/migration-backup/*
+
 # misc
 .DS_Store
 .env

--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ npm start
 
 This will start your project and open it in a browser tab.
 
+## Migrations
+
+1. `./node_modules/db-migrate/bin/db-migrate create [name]` to create new migration scripts with name `name`
+**Note:** When creating a migration scripts, don't forget to add MongoDB Collections backups (`mongodump`) before deleting collections and collection restores (`mongorestore`) while creating Collections
+
+2. `./node_modules/db-migrate/bin/db-migrate up` to execute the migration scripts and bring database up to the latest version
+
+3. `./node_modules/db-migrate/bin/db-migrate down` to rollback to the previous database version. (`--count NUM` for `NUM` down migrations)
+
 ## Acknowledgements
 
 This project used https://github.com/swbloom/react-express-boilerplate as a starting point.

--- a/database.json
+++ b/database.json
@@ -1,0 +1,7 @@
+{
+    "dev": {
+      "driver": "mongodb",
+      "database": "rangle-labs",
+      "host": "localhost"
+    }
+}

--- a/migrations/20181002193812-remove-projects-add-mentorship.js
+++ b/migrations/20181002193812-remove-projects-add-mentorship.js
@@ -16,13 +16,19 @@ exports.setup = function(options, seedLink) {
 };
 
 exports.up = function(db, cb) {
-  db.dropCollection('projects');
-  db.createCollection('mentorships');
-  cb();
-  return db;
+  if (shell.exec('mongorestore ./migration-backup/version2').code !== 0) { // restoring failed (could not find mentorship backup)
+    db.createCollection('mentorships');
+  }
+  if ( shell.exec('mongodump --collection projects --db rangle-labs --out ./migrations/migration-backup/version1').code === 0) {
+    db.dropCollection('projects');
+    cb();
+  } else {
+    cb(new Error('backing up of projects failed.'));
+  }
 };
 
 exports.down = function(db, cb) {
+  
   db.createCollection('projects');
   db.dropCollection('mentorships');
   cb();

--- a/migrations/20181002193812-remove-projects-add-mentorship.js
+++ b/migrations/20181002193812-remove-projects-add-mentorship.js
@@ -1,4 +1,5 @@
 'use strict';
+var shell = require('shelljs');
 
 var dbm;
 var type;

--- a/migrations/20181002193812-remove-projects-add-mentorship.js
+++ b/migrations/20181002193812-remove-projects-add-mentorship.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function(db) {
+  db.dropCollection('projects');
+  db.createCollection('mentorships');
+  return db;
+};
+
+exports.down = function(db) {
+  db.createCollection('projects');
+  db.dropCollection('mentorships');
+  return db;
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/20181002193812-remove-projects-add-mentorship.js
+++ b/migrations/20181002193812-remove-projects-add-mentorship.js
@@ -14,15 +14,17 @@ exports.setup = function(options, seedLink) {
   seed = seedLink;
 };
 
-exports.up = function(db) {
+exports.up = function(db, cb) {
   db.dropCollection('projects');
   db.createCollection('mentorships');
+  cb();
   return db;
 };
 
-exports.down = function(db) {
+exports.down = function(db, cb) {
   db.createCollection('projects');
   db.dropCollection('mentorships');
+  cb();
   return db;
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1676,6 +1676,11 @@
       "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
       "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g=="
     },
+    "buffer-shims": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
+    },
     "buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
@@ -3009,6 +3014,11 @@
         "array-find-index": "1.0.2"
       }
     },
+    "cycle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
+    },
     "d": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
@@ -3041,6 +3051,118 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
+    },
+    "db-migrate": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/db-migrate/-/db-migrate-0.11.3.tgz",
+      "integrity": "sha512-xpfPu08sq9LWqA8v5dUpyqKbNPlFZYsKB1etVxuPE4krQotshD+dd/qaX4a+wv5mlFpGiIo8cDls8yQPrJL6Bw==",
+      "requires": {
+        "balanced-match": "1.0.0",
+        "bluebird": "3.5.2",
+        "db-migrate-shared": "1.2.0",
+        "deep-extend": "0.5.1",
+        "dotenv": "5.0.1",
+        "final-fs": "1.6.1",
+        "inflection": "1.12.0",
+        "mkdirp": "0.5.1",
+        "optimist": "0.6.1",
+        "parse-database-url": "0.3.0",
+        "pkginfo": "0.4.1",
+        "prompt": "1.0.0",
+        "rc": "1.2.8",
+        "resolve": "1.8.1",
+        "semver": "5.5.1",
+        "tunnel-ssh": "4.1.4"
+      },
+      "dependencies": {
+        "deep-extend": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+          "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w=="
+        },
+        "dotenv": {
+          "version": "5.0.1",
+          "resolved": "http://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
+          "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow=="
+        }
+      }
+    },
+    "db-migrate-base": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/db-migrate-base/-/db-migrate-base-1.5.3.tgz",
+      "integrity": "sha512-dbJHFVYIY75vSOL3MD4qbpjilcwrYn7ZnTqsdA2AGs6w1mYugspfWEBea+uMgJVH/YsUFxw2AYPKRHCHUjhirw==",
+      "requires": {
+        "bluebird": "3.5.2"
+      }
+    },
+    "db-migrate-mongodb": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/db-migrate-mongodb/-/db-migrate-mongodb-1.4.0.tgz",
+      "integrity": "sha512-PFfBUWiAcoweBgoDCa7/46BD//YeH7R/fXtbUHlb+YwFJCe4kY6JjTmWt9a96vtoABynIG0MH/ZgqbB0j9svHQ==",
+      "requires": {
+        "bluebird": "3.5.2",
+        "db-migrate-base": "1.5.3",
+        "moment": "2.22.2",
+        "mongodb": "2.2.36"
+      },
+      "dependencies": {
+        "es6-promise": {
+          "version": "3.2.1",
+          "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
+          "integrity": "sha1-7FYjOGgDKQkgcXDDlEjiREndH8Q="
+        },
+        "mongodb": {
+          "version": "2.2.36",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.36.tgz",
+          "integrity": "sha512-P2SBLQ8Z0PVx71ngoXwo12+FiSfbNfGOClAao03/bant5DgLNkOPAck5IaJcEk4gKlQhDEURzfR3xuBG1/B+IA==",
+          "requires": {
+            "es6-promise": "3.2.1",
+            "mongodb-core": "2.1.20",
+            "readable-stream": "2.2.7"
+          }
+        },
+        "mongodb-core": {
+          "version": "2.1.20",
+          "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.20.tgz",
+          "integrity": "sha512-IN57CX5/Q1bhDq6ShAR6gIv4koFsZP7L8WOK1S0lR0pVDQaScffSMV5jxubLsmZ7J+UdqmykKw4r9hG3XQEGgQ==",
+          "requires": {
+            "bson": "1.0.9",
+            "require_optional": "1.0.1"
+          }
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+        },
+        "readable-stream": {
+          "version": "2.2.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
+          "integrity": "sha1-BwV6y+JGeyIELTb5jFrVBwVOlbE=",
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "requires": {
+            "safe-buffer": "5.1.2"
+          }
+        }
+      }
+    },
+    "db-migrate-shared": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/db-migrate-shared/-/db-migrate-shared-1.2.0.tgz",
+      "integrity": "sha512-65k86bVeHaMxb2L0Gw3y5V+CgZSRwhVQMwDMydmw5MvIpHHwD6SmBciqIwHsZfzJ9yzV/yYhdRefRM6FV5/siw=="
     },
     "debug": {
       "version": "3.1.0",
@@ -4577,6 +4699,11 @@
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
+    "eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
+    },
     "fast-deep-equal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
@@ -4669,6 +4796,15 @@
         "randomatic": "3.1.0",
         "repeat-element": "1.1.3",
         "repeat-string": "1.6.1"
+      }
+    },
+    "final-fs": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/final-fs/-/final-fs-1.6.1.tgz",
+      "integrity": "sha1-1tzZLvb+T+jAer1WjHE1YQ7eMjY=",
+      "requires": {
+        "node-fs": "0.1.7",
+        "when": "2.0.1"
       }
     },
     "finalhandler": {
@@ -5918,6 +6054,11 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
     },
+    "i": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/i/-/i-0.3.6.tgz",
+      "integrity": "sha1-2WyScyB28HJxG2sQ/X1PZa2O4j0="
+    },
     "iconv-lite": {
       "version": "0.4.23",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
@@ -5998,6 +6139,11 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
       "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
+    },
+    "inflection": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.12.0.tgz",
+      "integrity": "sha1-ogCTVlbW9fa8TcdQLhrstwMihBY="
     },
     "inflight": {
       "version": "1.0.6",
@@ -7488,6 +7634,11 @@
         "minimist": "0.0.8"
       }
     },
+    "moment": {
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
+      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
+    },
     "mongodb": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.1.4.tgz",
@@ -7514,6 +7665,11 @@
           "integrity": "sha512-9Aeai9TacfNtWXOYarkFJRW2CWo+dRon+fuLZYJmvLV3+MiUp0bEI6IAZfXEIg7/Pl/7IWlLaDnhzTsD81etQA=="
         }
       }
+    },
+    "mongodb-uri": {
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/mongodb-uri/-/mongodb-uri-0.9.7.tgz",
+      "integrity": "sha1-D3ca0W9IOuZfQoeWlCjp+8SqYYE="
     },
     "mongoose": {
       "version": "5.2.13",
@@ -7633,6 +7789,11 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
     },
+    "ncp": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npmjs.org/ncp/-/ncp-1.0.1.tgz",
+      "integrity": "sha1-0VNn5cuHQyuhF9K/gP30Wuz7QkY="
+    },
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
@@ -7666,6 +7827,11 @@
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz",
       "integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ=="
+    },
+    "node-fs": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/node-fs/-/node-fs-0.1.7.tgz",
+      "integrity": "sha1-MjI8zLRsn78PwRgS1FAhzDHTJbs="
     },
     "node-gyp": {
       "version": "3.8.0",
@@ -8237,6 +8403,14 @@
         "pbkdf2": "3.0.16"
       }
     },
+    "parse-database-url": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/parse-database-url/-/parse-database-url-0.3.0.tgz",
+      "integrity": "sha1-NpZmMh6SfJreY838Gqr2+zdFPQ0=",
+      "requires": {
+        "mongodb-uri": "0.9.7"
+      }
+    },
     "parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
@@ -8442,6 +8616,11 @@
       "requires": {
         "find-up": "2.1.0"
       }
+    },
+    "pkginfo": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
+      "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8="
     },
     "pluralize": {
       "version": "7.0.0",
@@ -9690,6 +9869,19 @@
         "asap": "2.0.6"
       }
     },
+    "prompt": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prompt/-/prompt-1.0.0.tgz",
+      "integrity": "sha1-jlcSPDlquYiJf7Mn/Trtw+c15P4=",
+      "requires": {
+        "colors": "1.1.2",
+        "pkginfo": "0.4.1",
+        "read": "1.0.7",
+        "revalidator": "0.1.8",
+        "utile": "0.3.0",
+        "winston": "2.1.1"
+      }
+    },
     "prop-types": {
       "version": "15.6.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
@@ -9982,6 +10174,14 @@
         "prop-types": "15.6.2",
         "react-router": "4.3.1",
         "warning": "4.0.2"
+      }
+    },
+    "read": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+      "requires": {
+        "mute-stream": "0.0.7"
       }
     },
     "read-pkg": {
@@ -10410,6 +10610,11 @@
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+    },
+    "revalidator": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
+      "integrity": "sha1-/s5hv6DBtSoga9axgZgYS91SOjs="
     },
     "right-align": {
       "version": "0.1.3",
@@ -11172,6 +11377,24 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
+    "ssh2": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-0.5.4.tgz",
+      "integrity": "sha1-G/a2soyW6u8mf01sRqWiUXpZnic=",
+      "requires": {
+        "ssh2-streams": "0.1.20"
+      }
+    },
+    "ssh2-streams": {
+      "version": "0.1.20",
+      "resolved": "https://registry.npmjs.org/ssh2-streams/-/ssh2-streams-0.1.20.tgz",
+      "integrity": "sha1-URGNFUVV31Rp7h9n4M8efoosDjo=",
+      "requires": {
+        "asn1": "0.2.4",
+        "semver": "5.5.1",
+        "streamsearch": "0.1.2"
+      }
+    },
     "sshpk": {
       "version": "1.14.2",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
@@ -11187,6 +11410,11 @@
         "safer-buffer": "2.1.2",
         "tweetnacl": "0.14.5"
       }
+    },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
     },
     "static-extend": {
       "version": "0.1.2",
@@ -11325,6 +11553,11 @@
           }
         }
       }
+    },
+    "streamsearch": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
     },
     "strict-uri-encode": {
       "version": "1.1.0",
@@ -11781,6 +12014,26 @@
         "safe-buffer": "5.1.2"
       }
     },
+    "tunnel-ssh": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tunnel-ssh/-/tunnel-ssh-4.1.4.tgz",
+      "integrity": "sha512-CjBqboGvAbM7iXSX2F95kzoI+c2J81YkrHbyyo4SWNKCzU6w5LfEvXBCHu6PPriYaNvfhMKzD8bFf5Vl14YTtg==",
+      "requires": {
+        "debug": "2.6.9",
+        "lodash.defaults": "4.2.0",
+        "ssh2": "0.5.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
@@ -12153,6 +12406,31 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
       "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw="
+    },
+    "utile": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/utile/-/utile-0.3.0.tgz",
+      "integrity": "sha1-E1LDQOuCDk2N26A5pPv6oy7U7zo=",
+      "requires": {
+        "async": "0.9.2",
+        "deep-equal": "0.2.2",
+        "i": "0.3.6",
+        "mkdirp": "0.5.1",
+        "ncp": "1.0.1",
+        "rimraf": "2.6.2"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "resolved": "http://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+        },
+        "deep-equal": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
+          "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0="
+        }
+      }
     },
     "utils-merge": {
       "version": "1.0.1",
@@ -12677,6 +12955,11 @@
         }
       }
     },
+    "when": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/when/-/when-2.0.1.tgz",
+      "integrity": "sha1-jYcv4V5oQkyRtLck6EjggH2rZkI="
+    },
     "whet.extend": {
       "version": "0.9.9",
       "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
@@ -12745,6 +13028,37 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
+    },
+    "winston": {
+      "version": "2.1.1",
+      "resolved": "http://registry.npmjs.org/winston/-/winston-2.1.1.tgz",
+      "integrity": "sha1-PJNJ0ZYgf9G9/51LxD73JRDjoS4=",
+      "requires": {
+        "async": "1.0.0",
+        "colors": "1.0.3",
+        "cycle": "1.0.3",
+        "eyes": "0.1.8",
+        "isstream": "0.1.2",
+        "pkginfo": "0.3.1",
+        "stack-trace": "0.0.10"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.0.0",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.0.0.tgz",
+          "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+        },
+        "colors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+        },
+        "pkginfo": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
+          "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE="
+        }
+      }
     },
     "wordwrap": {
       "version": "0.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10275,6 +10275,15 @@
         }
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "1.8.1"
+      }
+    },
     "recursive-readdir": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.1.tgz",
@@ -11006,6 +11015,17 @@
         "array-map": "0.0.0",
         "array-reduce": "0.0.0",
         "jsonify": "0.0.0"
+      }
+    },
+    "shelljs": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.2.tgz",
+      "integrity": "sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.3",
+        "interpret": "1.1.0",
+        "rechoir": "0.6.2"
       }
     },
     "shellwords": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "case-sensitive-paths-webpack-plugin": "2.1.1",
     "chalk": "1.1.3",
     "css-loader": "0.28.7",
+    "db-migrate": "^0.11.3",
+    "db-migrate-mongodb": "^1.4.0",
     "dotenv": "4.0.0",
     "dotenv-expand": "4.2.0",
     "express": "^4.16.2",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "node-sass": "^4.9.2",
     "nodemon": "^1.17.3",
     "sass-loader": "^7.1.0",
+    "shelljs": "^0.8.2",
     "yarn": "^1.9.4"
   },
   "jest": {

--- a/src/application/components/agents/agent-listing/agent-listing.js
+++ b/src/application/components/agents/agent-listing/agent-listing.js
@@ -62,7 +62,6 @@ class AgentListing extends Component {
       delete exportAgent.lastName;
       exportAgent.currentTechnologies = exportAgent.currentTechnologies.map(tech => tech.name);
       exportAgent.aspirationalTechnologies = exportAgent.aspirationalTechnologies.map(tech => tech.name);
-      console.log(exportAgent);
       return exportAgent;
     })
   }


### PR DESCRIPTION
@cybervinit and I decided to use [db-migrate](https://db-migrate.readthedocs.io/en/latest/search/): 

**Up:**
- Used [Shell.js](https://github.com/shelljs/shelljs#execcommand--options--callback) to call [mongodump](https://docs.mongodb.com/manual/reference/program/mongodump/#bin.mongodump) to create a backup of the projects collection before dropping it. 
- Restores mentorships with [mongorestore](https://docs.mongodb.com/manual/reference/program/mongorestore/#bin.mongorestore) if a backup exists
    - Otherwise will create a new mentorships collection. 

**Down:**
- Backs up mentorships before dropping 
- Restores projects. 

The backups are stored locally in migrations/migration-backup, under version folders. 

Currently we are only backing up the specific collection we are modifying (such as projects), and not the entire database. 